### PR TITLE
Added package.json as a test for new plugins.jquery.com site

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "AnythingZoomer",
+    "version": "1.1.2",
+    "title": "AnythingZoomer",
+    "author": {
+        "name": "Chris Coyier",
+        "url": "https://github.com/chriscoyier"
+    },
+    "licenses": [
+        {
+            "type": "MIT",
+            "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+    ],
+    "dependencies": {
+        "jquery": ">=1.3.2"
+    },
+    "description": "You have a small area. You mouse over it. An area pops up giving you a zoomed in closer look. This is a jQuery plugin that does it. I'm not going to tell you what you should use it for or elaborate use-case scenarios. Your own creativity can help you there.\n\nIt's flexible in many ways, in that the \"small\", \"large\", and \"zoom\" areas are all pretty easy to customize (via CSS). It's inflexible in other ways, in that it doesn't \"automatically\" work by cloning content or anything like that (which is arguably more flexible), and the HTML structure is fairly rigid.\n\n",
+    "keywords": [
+        "customizable",
+        "effects",
+        "elements",
+        "zooming"
+    ],
+    "homepage": "http://css-tricks.com/3075-anythingzoomer-jquery-plugin/",
+    "contributors": [
+        {
+            "name": "Rob G",
+            "url": "https://github.com/Mottie"
+        }
+    ],
+    "files": [
+        "css/jquery.anythingzoomer.css",
+        "js/jquery.anythingzoomer.js",
+        "js/jquery.anythingzoomer.min.js"
+    ]
+}


### PR DESCRIPTION
I'd love to test out this plugin on the new jQuery plugins site (read more at http://blog.jquery.com/2011/12/08/what-is-happening-to-the-jquery-plugins-site/ ) currently in development. That requires
1. a new file (in this pull request), package.json. The spec for that file is at https://github.com/jquery/plugins.jquery.com/blob/master/docs/package.md . Check and make sure it's all right, but at least I checked it's valid json.
2. a new tag, at least version 1.1.2. You'd have to do that, I don't think I can do a tag as a pull request, can I?

Note that I'm not actually sure which minimum version of jQuery this plugin requires. I selected >=1.3.2 for the dependencies field based on the version currently being used in the demos in this repo.

Thanks!
